### PR TITLE
Add CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+xmlns.novaapi.net


### PR DESCRIPTION
This adds the `CNAME` file and points it at [`xmlns.novaapi.net`](https://xmlns.novaapi.net).

Until this is merged, the website at the current location will continue to have broken styles.

## Requirements:
The following records set in the NOVA website DNS settings:
<strike>
```
A	xmlns	192.30.252.153
A	xmlns	192.30.252.154
```
</strike>

With GitHub Pages now supporting HTTPS for custom pages, [this instead needs to be](https://help.github.com/articles/troubleshooting-custom-domains/#https-errors):
```
A	xmlns	185.199.108.153
A	xmlns	185.199.109.153
A	xmlns	185.199.110.153
A	xmlns	185.199.111.153
```
or
```
CNAME	xmlns	nova-team.github.io
```

This has to be done by @calclavia who has access to the NOVA website DNS settings (see https://github.com/NOVA-Team/NOVA-Core/issues/207#issuecomment-223889902).

---

Once the above requirements are met, this can be merged.